### PR TITLE
Rename packages and use parallel stream for loop

### DIFF
--- a/src/org/impact2585/lib2585/Destroyable.java
+++ b/src/org/impact2585/lib2585/Destroyable.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 /**
  * SAM interface with a destroy() method

--- a/src/org/impact2585/lib2585/DoubleSolenoid.java
+++ b/src/org/impact2585/lib2585/DoubleSolenoid.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 import java.io.Serializable;
 

--- a/src/org/impact2585/lib2585/Executer.java
+++ b/src/org/impact2585/lib2585/Executer.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 /**
  * SAM interface with an execute() method

--- a/src/org/impact2585/lib2585/ExecuterBasedRobot.java
+++ b/src/org/impact2585/lib2585/ExecuterBasedRobot.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 import java.io.Serializable;
 

--- a/src/org/impact2585/lib2585/MultiMotor.java
+++ b/src/org/impact2585/lib2585/MultiMotor.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 import java.io.Serializable;
 

--- a/src/org/impact2585/lib2585/RobotEnvironment.java
+++ b/src/org/impact2585/lib2585/RobotEnvironment.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 import java.io.Serializable;
 

--- a/src/org/impact2585/lib2585/RunnableExecuter.java
+++ b/src/org/impact2585/lib2585/RunnableExecuter.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 import java.io.Serializable;
 import java.util.Vector;
@@ -13,17 +13,15 @@ public abstract class RunnableExecuter implements Executer, Serializable {
 	private final Vector<Runnable> runnables = new Vector<Runnable>();
 
 	/* (non-Javadoc)
-	 * @see org._2585robophiles.lib2585.Executer#execute()
+	 * @see org.impact2585.lib2585.Executer#execute()
 	 */
 	public void execute() {
 		//run all the runnables
-		for(int i = 0; i < runnables.size(); i++){
-			Runnable runnable = runnables.elementAt(i);
-			runnable.run();
-		}
+		runnables.parallelStream().forEach(runnable -> runnable.run());
 	}
 
 	/**
+	 * Accessor for the Runnable List
 	 * @return the runnables
 	 */
 	public synchronized Vector<Runnable> getRunnables() {

--- a/src/org/impact2585/lib2585/XboxConstants.java
+++ b/src/org/impact2585/lib2585/XboxConstants.java
@@ -1,4 +1,4 @@
-package org._2585robophiles.lib2585;
+package org.impact2585.lib2585;
 
 /**
  *	holds constants for Xbox 360 controller buttons and axes 


### PR DESCRIPTION
I renamed the packages so that the domain being used is http://impact2585.org and made it so that a parallel stream is used to iterate over the Runnables in `RunnableExecuter`.