### PR TITLE
Let user choose whether or not to use concurrency

### DIFF
--- a/src/org/impact2585/lib2585/RunnableExecuter.java
+++ b/src/org/impact2585/lib2585/RunnableExecuter.java
@@ -11,6 +11,22 @@ public abstract class RunnableExecuter implements Executer, Serializable {
 	private static final long serialVersionUID = -7700534735844195641L;
 	
 	private final Vector<Runnable> runnables = new Vector<Runnable>();
+	private boolean concurrent;
+	
+	/**
+	 * Just a default constructor. Concurrency will not be used.
+	 */
+	public RunnableExecuter(){
+		
+	}
+	
+	/**
+	 * Set whether or not the Runnables execute concurrently
+	 * @param concurrent concurrent to set
+	 */
+	public RunnableExecuter(boolean concurrent){
+		this.concurrent = concurrent;
+	}
 
 	/* (non-Javadoc)
 	 * @see org.impact2585.lib2585.Executer#execute()
@@ -18,7 +34,10 @@ public abstract class RunnableExecuter implements Executer, Serializable {
 	@Override
 	public void execute() {
 		//run all the runnables
-		runnables.parallelStream().forEach(runnable -> runnable.run());
+		if(concurrent)
+			runnables.parallelStream().forEach(runnable -> runnable.run());
+		else
+			runnables.forEach(runnable -> runnable.run());
 	}
 
 	/**


### PR DESCRIPTION
The user can choose whether or not to use concurrency in `RunnableExecuter` by passing a boolean into the constructor.