### PR TITLE
Overrode the disabledperiodic

### DIFF
--- a/src/org/impact2585/lib2585/ExecuterBasedRobot.java
+++ b/src/org/impact2585/lib2585/ExecuterBasedRobot.java
@@ -47,22 +47,14 @@ public abstract class ExecuterBasedRobot extends IterativeRobot implements Seria
 		executer.execute();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see edu.wpi.first.wpilibj.IterativeRobot#disabledInit()
-	 */
-	@Override
-	public void disabledInit() {
-
-	}
 
 	/*
 	 * (non-Javadoc)
 	 * @see edu.wpi.first.wpilibj.IterativeRobot#disabledPeriodic()
-	 */
+	 */	
 	@Override
 	public void disabledPeriodic() {
-
+		executer.execute();
 	}
 
 	/**


### PR DESCRIPTION
The disabled periodic method now calls the execute method for the executer, so that the user can now create an executer for when the robot is disabled.