### PR TITLE
Override disabledInit and add to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Lib2585 [![Build Status](https://travis-ci.org/Impact2585/Lib2585.svg?branch=mas
 
 This FRC library is made to supplement WPILibJ and has [documentation available](https://impact2585.github.io/Lib2585).
 
+To use Lib2585, all you need to do is include the jar file in your classpath!
+
 Downloads can be found on the [releases](https://github.com/2585Robophiles/Lib2585/releases) page. Releases are signed by one of our core developers: LoadingPleaseWait (Michael Murphey PGP Key ID: A1CFA14B) or KIllin-A13 (Amanuel Bayu PGP Key ID: B8AD8D5E).
 
 Lib2585 is dual licensed under the [GPL v3](http://www.gnu.org/licenses) and BSD License for WPILib.

--- a/src/org/impact2585/lib2585/ExecuterBasedRobot.java
+++ b/src/org/impact2585/lib2585/ExecuterBasedRobot.java
@@ -50,6 +50,14 @@ public abstract class ExecuterBasedRobot extends IterativeRobot implements Seria
 			executer.execute();
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.IterativeRobot#disabledInit()
+	 */
+	@Override
+	public void disabledInit() {
+		setExecuter(null);
+	}
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
The method `disabledInit` in `ExecuterBasedRobot` is being overridden once again and I added a line to the README file.