### PR TITLE
Put build on same line as gitter chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-Lib2585 [![Build Status](https://travis-ci.org/Impact2585/Lib2585.svg?branch=master)](https://travis-ci.org/Impact2585/Lib2585)
+Lib2585
 =======
 
+[![Build Status](https://travis-ci.org/Impact2585/Lib2585.svg?branch=master)](https://travis-ci.org/Impact2585/Lib2585)
 [![Join the chat at https://gitter.im/Impact2585/Lib2585](https://badges.gitter.im/Impact2585/Lib2585.svg)](https://gitter.im/Impact2585/Lib2585?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This FRC library is made to supplement WPILibJ and has [documentation available](https://impact2585.github.io/Lib2585).


### PR DESCRIPTION
The markdowns for the build button were moved so that the build button will be on the same line as the gitter chat button. 