### PR TITLE
Migrate FakeSpeedController from aerbot-junit. This closes #56

### DIFF
--- a/src/org/impact2585/lib2585/testing/FakeSpeedController.java
+++ b/src/org/impact2585/lib2585/testing/FakeSpeedController.java
@@ -1,0 +1,107 @@
+package org.impact2585.lib2585.testing;
+
+import edu.wpi.first.wpilibj.SpeedController;
+
+/**
+ * SpeedController used for testing
+ */
+public class FakeSpeedController implements SpeedController {
+	
+	private double speed, pidOutput;
+	private byte sync;
+	private boolean inverted;
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.PIDOutput#pidWrite(double)
+	 */
+	@Override
+	public void pidWrite(double output) {
+		pidOutput = output;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#disable()
+	 */
+	@Override
+	public void disable() {
+		speed = 0;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#get()
+	 */
+	@Override
+	public double get() {
+		return speed;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#set(double)
+	 */
+	@Override
+	public void set(double speed) {
+		this.speed = speed;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#set(double, byte)
+	 */
+	@Override
+	public void set(double speed, byte syncGroup) {
+		set(speed);
+		sync = syncGroup;
+	}
+
+	/**
+	 * @return the pidOutput
+	 */
+	public double getPidOutput() {
+		return pidOutput;
+	}
+
+	/**
+	 * @param pidOutput the pidOutput to set
+	 */
+	protected void setPidOutput(double pidOutput) {
+		this.pidOutput = pidOutput;
+	}
+
+	/**
+	 * @return the sync
+	 */
+	public byte getSync() {
+		return sync;
+	}
+
+	/**
+	 * @param sync the sync to set
+	 */
+	protected void setSync(byte sync) {
+		this.sync = sync;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#setInverted(boolean)
+	 */
+	@Override
+	public void setInverted(boolean isInverted) {
+		inverted = isInverted;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#getInverted()
+	 */
+	@Override
+	public boolean getInverted() {
+		return inverted;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wpi.first.wpilibj.SpeedController#stopMotor()
+	 */
+	@Override
+	public void stopMotor() {
+		speed = 0;
+	}
+
+}

--- a/test/org/impact2585/lib2585/tests/FakeSpeedControllerTest.java
+++ b/test/org/impact2585/lib2585/tests/FakeSpeedControllerTest.java
@@ -1,0 +1,70 @@
+package org.impact2585.lib2585.tests;
+
+
+import org.impact2585.lib2585.testing.FakeSpeedController;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ *Class for testing the FakeSpeedController
+ */
+public class FakeSpeedControllerTest {
+
+	private FakeSpeedController controller;
+	private double speed;
+	private boolean invert;
+	/**
+	 * Set up the FakeSpeedControllerTest
+	 */
+	@Before
+	public void setUp() {
+		controller = new FakeSpeedController();
+		invert = false;
+		speed = 0;
+	}
+
+	
+	/**
+	 *Test the FakeSpeedController 
+	 */
+	@Test
+	public void test() {
+		//test setting the speed
+		speed = 0.3;
+		controller.set(speed);
+		Assert.assertTrue(controller.get() == speed);
+		
+		//test inversion
+		invert = true;
+		controller.setInverted(invert);
+		//for verbosity
+		Assert.assertTrue(controller.getInverted() == true);
+		
+		//test inversion
+		invert = false;
+		controller.setInverted(invert);
+		Assert.assertTrue(controller.getInverted() == false);
+		
+		//test negative speed
+		speed = -0.2;
+		controller.set(speed);
+		Assert.assertTrue(controller.get() == speed);
+		
+		//test PIDController
+		speed = 1.0;
+		controller.pidWrite(speed);
+		Assert.assertTrue(controller.getPidOutput() == speed);
+		
+		//test disabling the motor
+		controller.disable();
+		Assert.assertTrue(controller.get() == 0);
+		
+		//test stopping the motor
+		controller.set(speed);
+		controller.stopMotor();
+		Assert.assertTrue(controller.get() == 0);
+	}
+
+}


### PR DESCRIPTION
The FakeSpeedController class was migrated from aerbot-junit. It serves as an abstraction layer in the event that one would want to test a motor controller without directly interacting with the hardware. 
